### PR TITLE
check_run webhookに対応

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - "5.4"
+  - 14

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "githubot": "^1.0.0"
   },
   "devDependencies": {
-    "ava": "^0.10.0",
+    "ava": "^1.0.0",
     "got": "^4.2.0",
     "hubot-mock-adapter": "^1.0.0",
     "hubot-test-helper": "^1.2.0",

--- a/src/express.coffee
+++ b/src/express.coffee
@@ -4,11 +4,11 @@ Express.action = (PullRequestConditionalMerge, github, logger, owner, setup, cal
   (req, res) ->
     res.end ""
 
-    return unless req.get('X-Github-Event') == "status"
+    return unless ["status", "check_run"].some (@action) -> @action == req.get('X-Github-Event')
 
-    data = req.body
-    repo = data.name.split('/')[1]
-    sha = data.sha
+    data = if @action == "status" then req.body else req.body.check_run
+    repo = req.body.repository.full_name.split('/')[1]
+    sha = data.sha ? data.head_sha
 
     logger?.debug "Receiving hook: repo=#{repo}, sha=#{sha}"
 

--- a/src/pull-request-conditional-merge.coffee
+++ b/src/pull-request-conditional-merge.coffee
@@ -59,7 +59,8 @@ class PullRequestConditionalMerge
       ss.some (s) ->
         s.state == "success"
 
-    checkSucceeds = @check_runs.every (check) ->
+    checkSucceeds = @check_runs.every (check) =>
+      @logger?.debug "status = #{check.status}, conclusion = #{check.conclusion}"
       check.status == "completed" && check.conclusion == "success"
 
     checkLength = @statuses.length + @check_runs.length
@@ -71,9 +72,9 @@ class PullRequestConditionalMerge
     @fetchIssue =>
       @logger?.debug "Fetched issue..."
       @fetchStatus =>
-        @logger?.debug "Fetched status..."
+        @logger?.debug "Fetched #{@statuses.length} status..."
         @fetchCheckRuns =>
-          @logger?.debug "Fetched check-runs..."
+          @logger?.debug "Fetched #{@check_runs.length} check-runs..."
           if @readyToMerge()
             @merge =>
               callback()

--- a/test/bot_test.coffee
+++ b/test/bot_test.coffee
@@ -71,7 +71,7 @@ test.cb "actions merges pull request", (t) =>
   response = httpMocks.createResponse()
 
   action = Exp.action PRCM, github, null, "soutaro", null, ->
-    t.ok scopes.merge.isDone()
+    t.truthy scopes.merge.isDone()
     t.is response.statusCode, 200
     t.is response._getData(), ""
     t.end()
@@ -95,7 +95,7 @@ test.cb "action calls setup function", (t) =>
     setupIsOK = pr != null
 
   action = Exp.action PRCM, github, null, "soutaro", setup, ->
-    t.ok setupIsOK
+    t.truthy setupIsOK
     t.end()
 
   action(request, response)

--- a/test/pull-request-conditional-merge_test.coffee
+++ b/test/pull-request-conditional-merge_test.coffee
@@ -45,6 +45,15 @@ test.cb "find pull request, fetch issue for label, fetch CI status, and merge", 
     ])
 
   nock('https://api.github.com')
+    .get('/repos/soutaro/reponame/commits/xyzzy/check-runs')
+    .reply(200, {
+      check_runs: [
+        status: "completed"
+        conclusion: "success"
+      ]
+    })
+
+  nock('https://api.github.com')
     .put('/repos/soutaro/reponame/pulls/1/merge')
     .reply(200, {})
 

--- a/test/ready_to_merge_test.coffee
+++ b/test/ready_to_merge_test.coffee
@@ -28,7 +28,7 @@ test "ready when open, label is given, CI passes", (t) ->
     }
   ]
 
-  t.ok pr.readyToMerge()
+  t.truthy pr.readyToMerge()
 
 test "not ready when label is missing, CI passes", (t) ->
   pr = new PRCM()
@@ -54,7 +54,7 @@ test "not ready when label is missing, CI passes", (t) ->
     }
   ]
 
-  t.notOk pr.readyToMerge()
+  t.falsy pr.readyToMerge()
 
 test "not ready when label is given, but CI fails", (t) ->
   pr = new PRCM()
@@ -80,7 +80,7 @@ test "not ready when label is given, but CI fails", (t) ->
     }
   ]
 
-  t.notOk pr.readyToMerge()
+  t.falsy pr.readyToMerge()
 
 test "not ready when label is given, but some CI fails", (t) ->
   pr = new PRCM()
@@ -106,7 +106,7 @@ test "not ready when label is given, but some CI fails", (t) ->
     }
   ]
 
-  t.notOk pr.readyToMerge()
+  t.falsy pr.readyToMerge()
 
 test "not ready when label is given, but no CI succeeded", (t) ->
   pr = new PRCM()
@@ -124,4 +124,4 @@ test "not ready when label is given, but no CI succeeded", (t) ->
   pr.statuses = [
   ]
 
-  t.notOk pr.readyToMerge()
+  t.falsy pr.readyToMerge()

--- a/test/ready_to_merge_test.coffee
+++ b/test/ready_to_merge_test.coffee
@@ -28,6 +28,8 @@ test "ready when open, label is given, CI passes", (t) ->
     }
   ]
 
+  pr.check_runs = []
+
   t.truthy pr.readyToMerge()
 
 test "not ready when label is missing, CI passes", (t) ->
@@ -53,6 +55,8 @@ test "not ready when label is missing, CI passes", (t) ->
       state: "pending"
     }
   ]
+
+  pr.check_runs = []
 
   t.falsy pr.readyToMerge()
 
@@ -80,6 +84,8 @@ test "not ready when label is given, but CI fails", (t) ->
     }
   ]
 
+  pr.check_runs = []
+
   t.falsy pr.readyToMerge()
 
 test "not ready when label is given, but some CI fails", (t) ->
@@ -106,6 +112,33 @@ test "not ready when label is given, but some CI fails", (t) ->
     }
   ]
 
+  pr.check_runs = []
+
+  t.falsy pr.readyToMerge()
+
+test "not ready when label is given, but some check-run fails", (t) ->
+  pr = new PRCM()
+
+  pr.pull = {
+    state: 'open'
+  }
+
+  pr.issue = {
+    labels: [
+      { name: "ShipIt" }
+    ]
+  }
+
+  pr.statuses = [
+  ]
+
+  pr.check_runs = [
+    {
+      status: "completed"
+      conclusion: "failed"
+    }
+  ]
+
   t.falsy pr.readyToMerge()
 
 test "not ready when label is given, but no CI succeeded", (t) ->
@@ -123,5 +156,7 @@ test "not ready when label is given, but no CI succeeded", (t) ->
 
   pr.statuses = [
   ]
+
+  pr.check_runs = []
 
   t.falsy pr.readyToMerge()


### PR DESCRIPTION
github actionで動作するCIは`status`ではなく`check_run`のwebhook eventしか送ってこないので`check_run`イベントにも対応します。

## check_run イベントの例
### Headers
```
Request URL: https://ubibot.herokuapp.com/merge-pullrequest
Request method: POST
Accept: */*
content-type: application/json
User-Agent: GitHub-Hookshot/e509757
X-GitHub-Delivery: 6ff0b500-bc46-11ea-922e-af553cfc7171
X-GitHub-Event: check_run
```

### Payload
```
{
  "action": "completed",
  "check_run": {
    "id": 829953600,
    "node_id": "MDg6Q2hlY2tSdW44Mjk5NTM2MDA=",
    "head_sha": "3912e44b3d6406b37b48192dc9e04c251e7592bb",
    "external_id": "174020594",
    "url": "https://api.github.com/repos/ubiregiinc/Bach/check-runs/829953600",
    "html_url": "https://github.com/ubiregiinc/Bach/runs/829953600",
    "details_url": "https://travis-ci.com/github/ubiregiinc/Bach/builds/174020594",
    "status": "completed",
    "conclusion": "failure",
```

## その他
- `t.end()`に辿り着かないとテストが固まるのでavaのバージョンを上げる
  - `t.ok -> t.truthy` `t.notOk -> t.falsy`に変わったので対応
- `use strict`しないと怒られるようになったのでTravis上のnodeバージョンを上げる