### PR TITLE
Use latest status

### DIFF
--- a/src/pull-request-conditional-merge.coffee
+++ b/src/pull-request-conditional-merge.coffee
@@ -56,8 +56,7 @@ class PullRequestConditionalMerge
     ciSucceeds = groupBy @statuses, (status) ->
       status.context
     .every (ss) ->
-      ss.some (s) ->
-        s.state == "success"
+      ss[0].state == "success"
 
     checkSucceeds = @check_runs.every (check) =>
       @logger?.debug "status = #{check.status}, conclusion = #{check.conclusion}"

--- a/test/ready_to_merge_test.coffee
+++ b/test/ready_to_merge_test.coffee
@@ -32,6 +32,35 @@ test "ready when open, label is given, CI passes", (t) ->
 
   t.truthy pr.readyToMerge()
 
+test "not ready when open, label is given, last CI is still running", (t) ->
+  pr = new PRCM()
+
+  pr.pull = {
+    state: 'open'
+  }
+
+  pr.issue = {
+    labels: [
+      { name: "ShipIt" }
+      { name: "WIP" }
+    ]
+  }
+
+  pr.statuses = [
+    {
+      context: "super-ci/pr"
+      state: "pending"
+    },
+    {
+      context: "super-ci/pr"
+      state: "success"
+    }
+  ]
+
+  pr.check_runs = []
+
+  t.falsy pr.readyToMerge()
+
 test "not ready when label is missing, CI passes", (t) ->
   pr = new PRCM()
 


### PR DESCRIPTION
同じ`context`のCIが複数回実行された時に、`status`が複数回記録されているが、1つでも成功していたらマージされてしまうようになっていた。
最新の結果を見るようにした。

参考: https://developer.github.com/v3/repos/statuses/#list-commit-statuses-for-a-reference
> Statuses are returned in reverse chronological order. The first status in the list will be the latest one.