### PR TITLE
Use mergeable_state

### DIFF
--- a/src/pull-request-conditional-merge.coffee
+++ b/src/pull-request-conditional-merge.coffee
@@ -28,18 +28,8 @@ class PullRequestConditionalMerge
     @logger = null
     @commitMessage = -> "Merge pull request \##{@pull.number}, via bot"
 
-  fetchIssue: (callback) ->
-    @github.get @pull._links.issue.href, (@issue) =>
-      callback()
-
-  fetchStatus: (callback) ->
-    @github.get @pull._links.statuses.href, (@statuses) =>
-      callback()
-
-  fetchCheckRuns: (callback) ->
-    check_runs_url = @pull._links.statuses.href.replace(/^(.+)\/statuses\/(.+)$/, '$1/commits/$2/check-runs')
-    @github.withOptions(apiVersion: 'antiope-preview').get check_runs_url, (res) =>
-      @check_runs = res.check_runs
+  fetchPullDetail: (callback) ->
+    @github.get @pull.url, (@pull) =>
       callback()
 
   merge: (callback) ->
@@ -52,31 +42,17 @@ class PullRequestConditionalMerge
     @github.put url, body, callback
 
   readyToMerge: () ->
-    hasLabel = @issue.labels.some (label) => label.name == @label
-    ciSucceeds = groupBy @statuses, (status) ->
-      status.context
-    .every (ss) ->
-      ss[0].state == "success"
+    hasLabel = @pull.labels.some (label) => label.name == @label
 
-    checkSucceeds = @check_runs.every (check) =>
-      @logger?.debug "status = #{check.status}, conclusion = #{check.conclusion}"
-      check.status == "completed" && check.conclusion == "success"
-
-    checkLength = @statuses.length + @check_runs.length
-
-    @logger?.debug "state = #{@pull.state}, hasLabel = #{hasLabel}, ciSucceeds = #{ciSucceeds}, checkSucceeds = #{checkSucceeds}"
-    @pull.state == "open" && hasLabel && ciSucceeds && checkSucceeds && checkLength > 0
+    @logger?.debug "mergeable_state = #{@pull.mergeable_state}, hasLabel = #{hasLabel}"
+    @pull.state == "open" && hasLabel && @pull.mergeable_state == "clean"
 
   mergeIfReady: (callback) ->
-    @fetchIssue =>
-      @logger?.debug "Fetched issue..."
-      @fetchStatus =>
-        @logger?.debug "Fetched #{@statuses.length} status..."
-        @fetchCheckRuns =>
-          @logger?.debug "Fetched #{@check_runs.length} check-runs..."
-          if @readyToMerge()
-            @merge =>
-              callback()
+    @fetchPullDetail =>
+      @logger?.debug "Fetched pull detail..."
+      if @readyToMerge()
+        @merge =>
+          callback()
 
   # PullRequestConditionalMerge.find @github, owner: "ubiregiinc", repo: "ubiregi-server", sha: "12345678", (pr) =>
   #   ....

--- a/test/bot_test.coffee
+++ b/test/bot_test.coffee
@@ -20,43 +20,22 @@ test.beforeEach =>
         head: {
           sha: "1234567890"
         }
-        state: "open",
-        _links: {
-          issue: {
-            href: "https://api.github.com/repos/soutaro/reponame/issues/1"
-          },
-          statuses: {
-            href: "https://api.github.com/repos/soutaro/reponame/statuses/xyzzy"
-          }
-        }
       },
     ])
 
   nock('https://api.github.com')
-    .get('/repos/soutaro/reponame/issues/1')
+    .get('/repos/soutaro/reponame/pulls/1')
     .reply(200, {
+      url: "https://api.github.com/repos/soutaro/reponame/pulls/1",
+      head: {
+        sha: "1234567890"
+      },
+      state: "open",
       labels: [
         { name: "Bug" },
         { name: "ShipIt" }
-      ]
-    })
-
-  nock('https://api.github.com')
-    .get('/repos/soutaro/reponame/statuses/xyzzy')
-    .reply(200, [
-      {
-        context: "ci/pr",
-        state: "success"
-      }
-    ])
-
-  nock('https://api.github.com')
-    .get('/repos/soutaro/reponame/commits/xyzzy/check-runs')
-    .reply(200, {
-      check_runs: [
-        status: "completed"
-        conclusion: "success"
-      ]
+      ],
+      mergeable_state: "clean"
     })
 
   scopes.merge = nock('https://api.github.com')

--- a/test/pull-request-conditional-merge_test.coffee
+++ b/test/pull-request-conditional-merge_test.coffee
@@ -4,7 +4,7 @@ github = require('githubot')
 
 PRCM = require('../src/pull-request-conditional-merge')
 
-test.cb "find pull request, fetch issue for label, fetch CI status, and merge", (t) ->
+test.cb "find pull request, fetch detail for mergeable_state, and merge", (t) ->
   nock('https://api.github.com')
     .get('/repos/soutaro/reponame/pulls')
     .reply(200, [
@@ -14,43 +14,22 @@ test.cb "find pull request, fetch issue for label, fetch CI status, and merge", 
         head: {
           sha: "1234567890"
         }
-        state: "open",
-        _links: {
-          issue: {
-            href: "https://api.github.com/repos/soutaro/reponame/issues/1"
-          },
-          statuses: {
-            href: "https://api.github.com/repos/soutaro/reponame/statuses/xyzzy"
-          }
-        }
       },
     ])
 
   nock('https://api.github.com')
-    .get('/repos/soutaro/reponame/issues/1')
+    .get('/repos/soutaro/reponame/pulls/1')
     .reply(200, {
+      url: "https://api.github.com/repos/soutaro/reponame/pulls/1",
+      head: {
+        sha: "1234567890"
+      },
+      state: "open",
       labels: [
         { name: "Bug" },
         { name: "ShipIt" }
-      ]
-    })
-
-  nock('https://api.github.com')
-    .get('/repos/soutaro/reponame/statuses/xyzzy')
-    .reply(200, [
-      {
-        context: "ci/pr",
-        state: "success"
-      }
-    ])
-
-  nock('https://api.github.com')
-    .get('/repos/soutaro/reponame/commits/xyzzy/check-runs')
-    .reply(200, {
-      check_runs: [
-        status: "completed"
-        conclusion: "success"
-      ]
+      ],
+      mergeable_state: "clean"
     })
 
   nock('https://api.github.com')

--- a/test/ready_to_merge_test.coffee
+++ b/test/ready_to_merge_test.coffee
@@ -3,189 +3,69 @@ nock = require("nock")
 
 PRCM = require('../src/pull-request-conditional-merge')
 
-test "ready when open, label is given, CI passes", (t) ->
+test "ready when open, mergeable_state is clean", (t) ->
   pr = new PRCM()
 
   pr.pull = {
-    state: 'open'
-  }
-
-  pr.issue = {
+    state: 'open',
     labels: [
-      { name: "ShipIt" }
+      { name: "ShipIt" },
       { name: "WIP" }
-    ]
+    ],
+    mergeable_state: "clean"
   }
-
-  pr.statuses = [
-    {
-      context: "super-ci/pr"
-      state: "success"
-    },
-    {
-      context: "super-ci/pr"
-      state: "pending"
-    }
-  ]
-
-  pr.check_runs = []
 
   t.truthy pr.readyToMerge()
 
-test "not ready when open, label is given, last CI is still running", (t) ->
+test "not ready when open, mergeable_state is unknown", (t) ->
   pr = new PRCM()
 
   pr.pull = {
-    state: 'open'
-  }
-
-  pr.issue = {
+    state: 'open',
     labels: [
-      { name: "ShipIt" }
+      { name: "ShipIt" },
       { name: "WIP" }
-    ]
+    ],
+    mergeable_state: "unknown"
   }
-
-  pr.statuses = [
-    {
-      context: "super-ci/pr"
-      state: "pending"
-    },
-    {
-      context: "super-ci/pr"
-      state: "success"
-    }
-  ]
-
-  pr.check_runs = []
 
   t.falsy pr.readyToMerge()
 
-test "not ready when label is missing, CI passes", (t) ->
+test "not ready when label is missing, mergeable_state is clean", (t) ->
   pr = new PRCM()
 
   pr.pull = {
-    state: 'open'
-  }
-
-  pr.issue = {
+    state: 'open',
     labels: [
       { name: "WIP" }
-    ]
+    ],
+    mergeable_state: "clean"
   }
-
-  pr.statuses = [
-    {
-      context: "super-ci/pr"
-      state: "success"
-    },
-    {
-      context: "super-ci/pr"
-      state: "pending"
-    }
-  ]
-
-  pr.check_runs = []
 
   t.falsy pr.readyToMerge()
 
-test "not ready when label is given, but CI fails", (t) ->
+test "not ready when label is given, but mergeable_state is unstable", (t) ->
   pr = new PRCM()
 
   pr.pull = {
-    state: 'open'
-  }
-
-  pr.issue = {
+    state: 'open',
     labels: [
       { name: "ShipIt" }
-    ]
+    ],
+    mergeable_state: "unstable"
   }
-
-  pr.statuses = [
-    {
-      context: "super-ci/pr"
-      state: "error"
-    },
-    {
-      context: "super-ci/pr"
-      state: "pending"
-    }
-  ]
-
-  pr.check_runs = []
 
   t.falsy pr.readyToMerge()
 
-test "not ready when label is given, but some CI fails", (t) ->
+test "not ready when label is given, but mergeable_state is blocked", (t) ->
   pr = new PRCM()
 
   pr.pull = {
-    state: 'open'
-  }
-
-  pr.issue = {
+    state: 'open',
     labels: [
       { name: "ShipIt" }
-    ]
+    ],
+    mergeable_state: "blocked"
   }
-
-  pr.statuses = [
-    {
-      context: "super-ci/pr"
-      state: "success"
-    },
-    {
-      context: "super-ci/push"
-      state: "error"
-    }
-  ]
-
-  pr.check_runs = []
-
-  t.falsy pr.readyToMerge()
-
-test "not ready when label is given, but some check-run fails", (t) ->
-  pr = new PRCM()
-
-  pr.pull = {
-    state: 'open'
-  }
-
-  pr.issue = {
-    labels: [
-      { name: "ShipIt" }
-    ]
-  }
-
-  pr.statuses = [
-  ]
-
-  pr.check_runs = [
-    {
-      status: "completed"
-      conclusion: "failed"
-    }
-  ]
-
-  t.falsy pr.readyToMerge()
-
-test "not ready when label is given, but no CI succeeded", (t) ->
-  pr = new PRCM()
-
-  pr.pull = {
-    state: 'open'
-  }
-
-  pr.issue = {
-    labels: [
-      { name: "ShipIt" }
-    ]
-  }
-
-  pr.statuses = [
-  ]
-
-  pr.check_runs = []
 
   t.falsy pr.readyToMerge()


### PR DESCRIPTION
CIで失敗している場合: `  "mergeable_state": "unstable",`
未レビューな場合: `  "mergeable_state": "blocked",`
どちらもpassしている場合: `  "mergeable_state": "clean",`

として返ってくるのでそれを見るようにしました。

参考: https://docs.github.com/en/graphql/reference/enums#mergestatestatus


```
curl -v https://api.github.com/repos/ubiregiinc/{repo_name}/pulls/1234 -H "Authorization: token {YOUR_TOKEN_HERE}"
```

みたいな感じでいろんな状態のPRをAPIで取得してみるとどういう状態で何が返ってくるかわかります